### PR TITLE
Fix creating nested message in oneof not being marked as set

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1815,6 +1815,7 @@ class Translator:
 				nesting += 1
 				text += generate_group_clear(field_index, nesting)
 				text += tabulate("_" + f.name + ".value = " + the_class_name + ".new()\n", nesting)
+				text += tabulate("data[" + f.tag + "].state = PB_SERVICE_STATE.FILLED\n", nesting)
 				text += tabulate("return _" + f.name + ".value\n", nesting)
 		elif f.field_type == Analysis.FIELD_TYPE.MAP:
 			var the_class_name : String = class_table[f.type_class_id].parent_name + "." + class_table[f.type_class_id].name


### PR DESCRIPTION
Given a protobuf 3 file:
```proto
message Test {
  oneof foo {
    uint32 field1 = 1;
    uint32 field2 = 2;
  }
}
```
and Godot code:
```gdscript
test.set_field1(1234)
print(test.has_field1())
```
Currently it prints False, which is wrong since the field has been set. This PR fixes this issue.