### PR TITLE
Add command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Godobuf is easy to use, does not require rebuilding the Godot, because it is wri
 
 ## Usage
 
+### From the User Interface
 1. Open file dialog window `Input protobuf file`.
 2. Choose *.proto file in a dialog window.<br/>
 ![Input protobuf file](/readme-images/4.png)<br/>
@@ -71,6 +72,10 @@ Godobuf is easy to use, does not require rebuilding the Godot, because it is wri
 ![Alert](/readme-images/6.png)<br/>
 9. If compilation was successful a new GDScript will be created in a specified directory.
 10. Use script in you project.
+
+### From the Command Line
+1. From the root folder of your project, run `godot -s addons/protobuf/protobuf_cmdln.gd --input=A.proto --output=my_proto.gd`
+2. Optionally, define an alias: `alias godobuf='godot -s addons/protobuf/protobuf_cmdln.gd'`
 
 ## Mapping of protocol buffers datatypes to GDScript
 

--- a/addons/protobuf/protobuf_cmdln.gd
+++ b/addons/protobuf/protobuf_cmdln.gd
@@ -63,3 +63,5 @@ func _init():
 		print("Compiled '", input_file_name, "' to '", output_file_name, "'.")
 	else:
 		error("Compilation failed.")
+
+	quit()

--- a/addons/protobuf/protobuf_cmdln.gd
+++ b/addons/protobuf/protobuf_cmdln.gd
@@ -1,0 +1,65 @@
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2018, Oleg Malyavkin
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+extends SceneTree
+
+var Parser = preload("res://addons/protobuf/parser.gd")
+var Util = preload("res://addons/protobuf/protobuf_util.gd")
+
+func error(msg : String):
+	push_error(msg)
+	OS.exit_code = 1
+	quit()
+
+func _init():
+	var arguments = {}
+	for argument in OS.get_cmdline_args():
+		if argument.find("=") > -1:
+			var key_value = argument.split("=")
+			arguments[key_value[0].lstrip("--")] = key_value[1]
+
+	if !arguments.has("input") || !arguments.has("output"):
+		error("Expected 2 Parameters: input and output")
+
+	var input_file_name = arguments["input"]
+	var output_file_name = arguments["output"]
+
+	var file = File.new()
+	if file.open(input_file_name, File.READ) < 0:
+		error("File: '" + input_file_name + "' not found.")
+
+	var parser = Parser.new()
+
+	if parser.work(Util.extract_dir(input_file_name), Util.extract_filename(input_file_name), \
+		output_file_name, "res://addons/protobuf/protobuf_core.gd"):
+		print("Compiled '", input_file_name, "' to '", output_file_name, "'.")
+	else:
+		error("Compilation failed.")

--- a/addons/protobuf/protobuf_ui_dock.gd
+++ b/addons/protobuf/protobuf_ui_dock.gd
@@ -33,6 +33,7 @@ tool
 extends VBoxContainer
 
 var Parser = preload("res://addons/protobuf/parser.gd")
+var Util = preload("res://addons/protobuf/protobuf_util.gd")
 
 var input_file_name = null
 var output_file_name = null
@@ -90,26 +91,10 @@ func _on_CompileButton_pressed():
 	
 	var parser = Parser.new()
 	
-	if parser.work(_exstract_dir(input_file_name), _extract_filename(input_file_name), \
+	if parser.work(Util.extract_dir(input_file_name), Util.extract_filename(input_file_name), \
 		output_file_name, "res://addons/protobuf/protobuf_core.gd"):
 		show_dialog($SuccessAcceptDialog)
 	else:
 		show_dialog($FailAcceptDialog)
 	
 	return
-
-func _exstract_dir(file_path):
-	var parts = file_path.split("/", false)
-	parts.remove(parts.size() - 1)
-	var path
-	if file_path.begins_with("/"):
-		path = "/"
-	else:
-		path = ""
-	for part in parts:
-		path += part + "/"
-	return path
-
-func _extract_filename(file_path):
-	var parts = file_path.split("/", false)
-	return parts[parts.size() - 1]

--- a/addons/protobuf/protobuf_util.gd
+++ b/addons/protobuf/protobuf_util.gd
@@ -1,0 +1,46 @@
+#
+# BSD 3-Clause License
+#
+# Copyright (c) 2018, Oleg Malyavkin
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+static func extract_dir(file_path):
+	var parts = file_path.split("/", false)
+	parts.remove(parts.size() - 1)
+	var path
+	if file_path.begins_with("/"):
+		path = "/"
+	else:
+		path = ""
+	for part in parts:
+		path += part + "/"
+	return path
+
+static func extract_filename(file_path):
+	var parts = file_path.split("/", false)
+	return parts[parts.size() - 1]


### PR DESCRIPTION
I want to be able to compile the protobuf files during a CI workflow, so I need to call this addon from the terminal. From local testing it generated the same output when calling from the terminal as when calling from the UI.

I did get a strange error message after compilation though:

```
* Output file was created successfully. *
Compiled 'redacted' to 'redacted'.
ERROR: ~List: Condition "_first != __null" is true.
   At: ./core/self_list.h:112.
ERROR: ~List: Condition "_first != __null" is true.
   At: ./core/self_list.h:112.
WARNING: cleanup: ObjectDB instances leaked at exit (run with --verbose for details).
   At: core/object.cpp:2132.
ERROR: clear: Resources still in use at exit (run with --verbose for details).
   At: core/resource.cpp:450.

Process finished with exit code 0
```

Not quite sure what to do about the error message, I do not know Godot that well yet. 

```
ERROR: clear: Resources still in use at exit (run with --verbose for details).
   At: core/resource.cpp:450.
```

seems to go away if I delete 
```
tool
extends Node
```

from parser.gd, but I did not dare to remove it in this Pull Request.