### PR TITLE
Refactor + fix bugs in repeated field code generation

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1787,7 +1787,7 @@ class Translator:
 		var text : String = ""
 		var f : Analysis.ASTField = field_table[field_index]
 		text += tabulate("var _" + f.name + ": PBField\n", nesting)
-		if f.field_type == Analysis.FIELD_TYPE.MESSAGE:
+		if f.field_type == Analysis.FIELD_TYPE.MESSAGE and f.qualificator != Analysis.FIELD_QUALIFICATOR.REPEATED:
 			var the_class_name : String = class_table[f.type_class_id].parent_name + "." + class_table[f.type_class_id].name
 			the_class_name = the_class_name.substr(1, the_class_name.length() - 1)
 			text += generate_has_oneof(field_index, nesting)


### PR DESCRIPTION
This should only have two major changes in generated code:
- fixes #21: the "clear" method for repeated fields now sets it to an array instead of the field's type, e.g. int32
- fixes #22: now has a setter for repeated fields

Diffs of generated repeated scalar code:
![image](https://user-images.githubusercontent.com/4420888/147521481-780cb250-fdeb-47bc-87ae-4a8a35552eb8.png)

And an example of a generated repeated message code (`ModeState` is a message defined elsewhere):
![image](https://user-images.githubusercontent.com/4420888/147521723-a26bfe22-9c33-4210-8868-6423ababf7ae.png)

