### PR TITLE
Add has_ function for optionals

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1811,9 +1811,20 @@ class Translator:
 			var the_class_name : String = class_table[f.type_class_id].parent_name + "." + class_table[f.type_class_id].name
 			the_class_name = the_class_name.substr(1, the_class_name.length() - 1)
 			text += generate_has_oneof(field_index, nesting)
+			if f.qualificator != Analysis.FIELD_QUALIFICATOR.OPTIONAL:
+				text += generate_has_oneof(field_index, nesting)
 			if f.qualificator == Analysis.FIELD_QUALIFICATOR.REPEATED:
 				text += tabulate("func get_" + f.name + "() -> Array[" + the_class_name + "]:\n", nesting)
 			else:
+				if f.qualificator == Analysis.FIELD_QUALIFICATOR.OPTIONAL:
+					text += tabulate("func has_" + f.name + "() -> bool:\n", nesting)
+					nesting += 1
+					text += tabulate("if " + varname + ".value != null:\n", nesting)
+					nesting += 1
+					text += tabulate("return true\n", nesting)
+					nesting -= 1
+					text += tabulate("return false\n", nesting)
+					nesting -= 1
 				text += tabulate("func get_" + f.name + "() -> " + the_class_name + ":\n", nesting)
 			nesting += 1
 			text += tabulate("return " + varname + ".value\n", nesting)
@@ -1934,7 +1945,7 @@ class Translator:
 				if f.qualificator == Analysis.FIELD_QUALIFICATOR.OPTIONAL:
 					text += tabulate("func has_" + f.name + "() -> bool:\n", nesting)
 					nesting += 1
-					text += tabulate("if _" + f.name + ".value:\n", nesting)
+					text += tabulate("if " + varname + ".value != null:\n", nesting)
 					nesting += 1
 					text += tabulate("return true\n", nesting)
 					nesting -= 1

--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1931,6 +1931,15 @@ class Translator:
 				var array_type := "[" + gd_type + "]" if gd_type else ""
 				text += tabulate("func get_" + f.name + "() -> Array" + array_type + ":\n", nesting)
 			else:
+				if f.qualificator == Analysis.FIELD_QUALIFICATOR.OPTIONAL:
+					text += tabulate("func has_" + f.name + "() -> bool:\n", nesting)
+					nesting += 1
+					text += tabulate("if _" + f.name + ".value:\n", nesting)
+					nesting += 1
+					text += tabulate("return true\n", nesting)
+					nesting -= 1
+					text += tabulate("return false\n", nesting)
+					nesting -= 1
 				text += tabulate("func get_" + f.name + "()" + return_type + ":\n", nesting)
 			nesting += 1
 			text += tabulate("return " + varname + ".value\n", nesting)


### PR DESCRIPTION
Optional fields can return `null` if they are not present. Since the function is typed, and Godot currently has no nullable static types per https://github.com/godotengine/godot-proposals/issues/162, this can fail.  I propose adding a "has_" method if the field is optional. 

e.g.. This fails:
```gdscript
var mass = obj.get_mass() 
```
with the following error if the field is not set in the protobuf message:
`Trying to return value of type "Nil" from a function which the return type is "float".` 

because get_mass() is defined as:
```gdscript
func get_mass() -> float:
    return _mass.value
```
which cannot return nil. 

This patch introduces a new function to generate, e.g.: 
```gdscript
func has_mass() -> bool:
    if _mass.value != null:
        return true
    return false
```
So callers can check if the field is set before attempting to get the value. 