### PR TITLE
Fix type error when accessing repeated fields after clearing

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1833,7 +1833,7 @@ class Translator:
 			nesting += 1
 			text += tabulate("data[" + str(f.tag) + "].state = PB_SERVICE_STATE.UNFILLED\n", nesting)
 			if f.qualificator == Analysis.FIELD_QUALIFICATOR.REPEATED:
-				text += tabulate(varname + ".value = []\n", nesting)
+				text += tabulate(varname + ".value.clear()\n", nesting)
 				nesting -= 1
 				text += tabulate("func add_" + f.name + "() -> " + the_class_name + ":\n", nesting)
 				nesting += 1
@@ -1959,7 +1959,7 @@ class Translator:
 			nesting += 1
 			text += tabulate("data[" + str(f.tag) + "].state = PB_SERVICE_STATE.UNFILLED\n", nesting)
 			if f.qualificator == Analysis.FIELD_QUALIFICATOR.REPEATED:
-				text += tabulate(varname + ".value = []\n", nesting)
+				text += tabulate(varname + ".value.clear()\n", nesting)
 				nesting -= 1
 				text += tabulate("func add_" + f.name + "(value" + argument_type + ") -> void:\n", nesting)
 				nesting += 1


### PR DESCRIPTION
The previous logic replaced the typed array with an untyped array. This caused any further call to get_*** to fail with a type error because the get function expects the array to be a typed array.

Instead, we call .clear() on the array now, which will preserve its type.