### PR TITLE
Strip prefix from enum values

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -2005,8 +2005,18 @@ class Translator:
 		elif class_table[class_index].type == Analysis.CLASS_TYPE.ENUM:
 			text += tabulate("enum " + class_table[class_index].name + " {\n", nesting)
 			nesting += 1
+
+			var expected_prefix = class_table[class_index].name.to_snake_case().to_upper() + "_"
+			var all_have_prefix = true
 			for en in range(class_table[class_index].values.size()):
-				var enum_val = class_table[class_index].values[en].name + " = " + class_table[class_index].values[en].value
+				var value_name = class_table[class_index].values[en].name
+				all_have_prefix = all_have_prefix and value_name.begins_with(expected_prefix) and value_name != expected_prefix
+
+			for en in range(class_table[class_index].values.size()):
+				var value_name = class_table[class_index].values[en].name
+				if all_have_prefix:
+					value_name = value_name.substr(expected_prefix.length())
+				var enum_val = value_name + " = " + class_table[class_index].values[en].value
 				if en == class_table[class_index].values.size() - 1:
 					text += tabulate(enum_val + "\n", nesting)
 				else:


### PR DESCRIPTION
It is best practice in protobuf to prefix all enum values with the enum's name to avoid conflicts in languages where all enum values are in the global namespace.

Most protobuf compilers for languages where enum values are not in the global namespace strip this prefix to avoid the redundant name duplication.

Example:

enum InternalColorId {
  INTERNAL_COLOR_ID_UNSPECIFIED = 0;
  INTERNAL_COLOR_ID_RED = 1;
  INTERNAL_COLOR_ID_GREEN = 2;
}

becomes

public enum InternalColorId {
  Unspecified = 0,
  Red = 1,
  Green = 2
}

in C#.

This change makes it so that Godobuf strips the prefix as well, allowing you to write

var color := InternalColorId.RED;

instead of

var color := InternalColorId.INTERNAL_COLOR_ID_RED;

The prefix is stripped only if it matches the enum name and if every value in the enum uses the same prefix.