### PR TITLE
Skip unknown fields

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1810,7 +1810,6 @@ class Translator:
 		if f.field_type == Analysis.FIELD_TYPE.MESSAGE:
 			var the_class_name : String = class_table[f.type_class_id].parent_name + "." + class_table[f.type_class_id].name
 			the_class_name = the_class_name.substr(1, the_class_name.length() - 1)
-			text += generate_has_oneof(field_index, nesting)
 			if f.qualificator != Analysis.FIELD_QUALIFICATOR.OPTIONAL:
 				text += generate_has_oneof(field_index, nesting)
 			if f.qualificator == Analysis.FIELD_QUALIFICATOR.REPEATED:


### PR DESCRIPTION
Protobuf is designed to be both forwards- and backwards-compatible. Older parser versions encountering an unknown field should skip / ignore that field and still successfully parse the fields they understand. Similarly, fields may be deleted from the protobuf definition and messages containing the old fields should still be parseable.

The current godobuf implementation instead fails to parse messages with unknown fields because it only reads the tag varint and then pretends that the field were empty. In the best case, this causes it to fail with an error code. In the worst case, it causes it to misinterpret the unknown field's data as another field, leading to corrupted data.

This PR fixes the issue by skipping over unknown fields.

Note that unlike some other protobuf implementations, this will always discard the contents of the unknown fields rather than preserving them when re-serializing the message. While that would be a great feature for some use cases, it is mostly needed for services that manipulate and pass through messages, which are not usually written in gdscript.