### PR TITLE
Fix incorrect type_class_id's after merging of imported files

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -1535,6 +1535,8 @@ class Semantic:
 				if f.type_name[0] == ".":
 					f.type_class_id = find_full_class_name(f.type_name)
 				else:
+					# Reset result from previous assignment, that can be incorrect because of merging of imports
+					f.type_class_id = -1
 					var splited_name : Array = f.type_name.split(".", false)
 					var cur_class_index : int = f.parent_class_id
 					var exit : bool = false


### PR DESCRIPTION
When generating GDScript code from protobuf file, that uses imports, that are using imports themselves, it can occur, that after merging the analysis data from multiple files the type_class_id values will get invalidated. Because of that, they need to be recalculated.

This change fixes a bug, that occur when after the second run of semantock.check() indexes are not getting reassigned, because the program keeps the result of previous run. Because of that bug, the generated code becomes completely invalid.

## Steps to reproduce the original bug

1. Have the following proto files (imports skipped for brevity):
```proto
// envelope.proto
// ... imports
message Ping {}
message Pong {}
message Envelope {
  uint64 ts = 1;
  oneof payload {
    Ping ping = 10;
    Pong pong = 11;
    MessageSA sa = 100;
    MessageSB sb = 101;
    MessageSC sc = 102;
    MessageCA ca = 200;
    MessageCB cb = 201;
    MessageCC cc = 202;
  }
}

// message_s_a.proto
message MessageSA {
  string u = 1;
}
// message_s_b.proto
message MessageSB {
  bool suc = 1;
  string err = 2;
}
// message_s_c.proto
message MessageSC {
  enum EnumSC {
    ENUM_SC_UNSPECIFIED = 0;
    ENUM_SC_A = 1;
    ENUM_SC_B = 2;
    ENUM_SC_C = 3;
  }
  EnumSC act = 1;
}
// message_c_a.proto
message MessageCA {}
// message_c_b.proto
message MessageCB {
  uint64 ts = 1;
  uint32 c = 2;
  uint32 m = 3;
  EnumA enu_val = 4;
} 
// enum_a.proto
enum EnumA {
  ENUM_A_UNSPECIFIED = 0;
  ENUM_A_ALPHA = 1;
  ENUM_A_BETA = 2;
  ENUM_A_GAMMA = 3;
}
// message_c_c.proto
message MessageCC {
  uint64 etwas = 1;
}
```
2. Use envelope.proto as a source file for godobuf
3. Compile using godobuf docker 
4. Open generated .gd file - with bug it should show errors
