### PR TITLE
Get rid of infinite loop in unpack_varint

### DIFF
--- a/addons/protobuf/protobuf_core.gd
+++ b/addons/protobuf/protobuf_core.gd
@@ -226,6 +226,7 @@ class PBPacker:
 		var i: int = varint_bytes.size() - 1
 		while i > -1:
 			value = (value << 7) | (varint_bytes[i] & 0x7F)
+			i -= 1
 		return value
 
 	static func pack_type_tag(type : int, tag : int) -> PackedByteArray:


### PR DESCRIPTION
It looks like this was changed in the most recent commit https://github.com/oniksan/godobuf/commit/d105f419a139fde92048d8688ba8ff077b84714f . Previously, it had been written as:

```
for i in range(varint_bytes.size() - 1, -1, -1):
    value |= varint_bytes[i] & 0x7F
    if i != 0:
        value <<= 7
```

the prior `for` loop would exit, but without modifying `i` this changed `while` loop will not.