### PR TITLE
Add custom message prefixes and class_name

### DIFF
--- a/addons/protobuf/parser.gd
+++ b/addons/protobuf/parser.gd
@@ -45,12 +45,14 @@ class Document:
 
 class PrefixOptions:
 
-	func _init(pre : String, spe : bool = false):
+	func _init(pre : String, spe : bool = false, cn : String = ""):
 		prefix = pre
 		should_prefix_enums = spe
+		custom_class_name = cn
 
 	var prefix: String = ""
 	var should_prefix_enums : bool
+	var custom_class_name: String = ""
 
 
 class TokenPosition:
@@ -2111,6 +2113,8 @@ class Translator:
 		var text : String = ""
 		var nesting : int = 0
 		core_text = core_text.replace(PROTO_VERSION_DEFAULT, PROTO_VERSION_CONST + str(proto_version))
+		if prefix_options.custom_class_name != "":
+			text += "class_name " + prefix_options.custom_class_name + "\n\n"
 		text += core_text + "\n\n\n"
 		text += "############### USER DATA BEGIN ################\n"
 		var cls_user : String = ""
@@ -2254,14 +2258,15 @@ func work(
 	in_file : String,
 	out_file : String,
 	core_file : String,
-	custom_prefix: String = "",
-	should_prefix_enums: bool = false,
+	custom_prefix : String = "",
+	should_prefix_enums : bool = false,
+	custom_class_name : String = "",
 ) -> bool:
 
 	var in_full_name : String = path + in_file
 	var imports : Array = []
 	var analyzes : Dictionary = {}
-	var prefix_options : PrefixOptions = PrefixOptions.new(custom_prefix, should_prefix_enums)
+	var prefix_options : PrefixOptions = PrefixOptions.new(custom_prefix, should_prefix_enums, custom_class_name)
 	
 	print("Compiling source: '", in_full_name, "', output: '", out_file, "'.")
 	print("\n1. Parsing:")

--- a/addons/protobuf/protobuf_cmdln.gd
+++ b/addons/protobuf/protobuf_cmdln.gd
@@ -71,6 +71,13 @@ func _init():
 		else:
 			error("should_prefix_enums is not true or false")
 
+	var custom_class_name = ""
+	if arguments.has("class_name"):
+		custom_class_name = arguments["class_name"]
+
+		if !custom_class_name.is_valid_identifier():
+			error("The provided class_name is not a valid identifier: " + custom_class_name)
+
 	var file = FileAccess.open(input_file_name, FileAccess.READ)
 	if file == null:
 		error("File: '" + input_file_name + "' not found.")
@@ -78,7 +85,9 @@ func _init():
 	var parser = Parser.new()
 
 	if parser.work(Util.extract_dir(input_file_name), Util.extract_filename(input_file_name), \
-		output_file_name, "res://addons/protobuf/protobuf_core.gd", message_prefix, should_prefix_enums):
+		output_file_name, "res://addons/protobuf/protobuf_core.gd", \
+		message_prefix, should_prefix_enums, custom_class_name):
+
 		print("Compiled '", input_file_name, "' to '", output_file_name, "'.")
 	else:
 		error("Compilation failed.")

--- a/addons/protobuf/protobuf_ui_dock.gd
+++ b/addons/protobuf/protobuf_ui_dock.gd
@@ -87,10 +87,18 @@ func _on_CompileButton_pressed():
 
 	var should_prefix_enums = $EnumPrefixCheckButton.is_pressed()
 
+	var custom_class_name = ""
+	if $ClassNameCheckButton.is_pressed():
+		custom_class_name = $HBoxContainer4/ClassNameEdit.text
+
+		if !custom_class_name.is_valid_identifier():
+			show_dialog($ClassNameErrorAcceptDialog)
+			return
+
 	var parser = Parser.new()
 	
 	if parser.work(Util.extract_dir(input_file_path), Util.extract_filename(input_file_path), \
-		output_file_path, "res://addons/protobuf/protobuf_core.gd", message_prefix, should_prefix_enums):
+		output_file_path, "res://addons/protobuf/protobuf_core.gd", message_prefix, should_prefix_enums, custom_class_name):
 		show_dialog($SuccessAcceptDialog)
 	else:
 		show_dialog($FailAcceptDialog)

--- a/addons/protobuf/protobuf_ui_dock.tscn
+++ b/addons/protobuf/protobuf_ui_dock.tscn
@@ -68,10 +68,23 @@ text = "Use the prefix in enum names?"
 [node name="HSeparator2" type="HSeparator" parent="."]
 layout_mode = 2
 
-[node name="HSeparator2" type="HSeparator" parent="HSeparator2"]
+[node name="ClassNameCheckButton" type="CheckButton" parent="."]
 layout_mode = 2
-offset_right = 421.0
-offset_bottom = 4.0
+text = "Use a custom class_name?"
+
+[node name="HBoxContainer4" type="HBoxContainer" parent="."]
+layout_mode = 2
+
+[node name="ClassNameLabel" type="Label" parent="HBoxContainer4"]
+layout_mode = 2
+text = "Class name:"
+
+[node name="ClassNameEdit" type="LineEdit" parent="HBoxContainer4"]
+layout_mode = 2
+size_flags_horizontal = 3
+
+[node name="HSeparator3" type="HSeparator" parent="."]
+layout_mode = 2
 
 [node name="Control" type="Control" parent="."]
 layout_mode = 2
@@ -113,6 +126,9 @@ dialog_text = "Need select both output & input files!"
 
 [node name="PrefixErrorAcceptDialog" type="AcceptDialog" parent="."]
 dialog_text = "The provided prefix is not a valid identifier!"
+
+[node name="ClassNameAcceptDialog" type="AcceptDialog" parent="."]
+dialog_text = "The provided class_name is not a valid identifier!"
 
 [node name="SuccessAcceptDialog" type="AcceptDialog" parent="."]
 dialog_text = "Compile success done."


### PR DESCRIPTION
This PR provides a couple of QoL options to tweak the GDScript output.

1. specify a custom prefix to add to the start of our proto messages. This prefix can be optionally added to our enums as well. This was requested in #43. 
2. specify a custom `class_name` to unlock global access to our script without manual loading.


As an example, see the following proto file:
```
syntax = "proto3";

message Person {
	string name = 1;
	int32 id = 2;
	string email = 3;

	enum PhoneType {
		MOBILE = 0;
		HOME = 1;
		WORK = 2;
	}

	message PhoneNumber {
		string number = 1;
		PhoneType type = 2;
	}

	repeated PhoneNumber phones = 4;
}

message AddressBook {
	repeated Person people = 1;
}

```

And here's an excerpt from the output GDScript with a custom class name (`PB`), message prefix (`Prefix`), and enum prefixes enabled.
```
class_name PB

...

############### USER DATA BEGIN ################

class PrefixPerson:
	
	...
	
	var __phones: PBField
	func get_phones() -> Array[PrefixPerson.PrefixPhoneNumber]:
		return __phones.value
	func clear_phones() -> void:
		data[4].state = PB_SERVICE_STATE.UNFILLED
		__phones.value.clear()
	func add_phones() -> PrefixPerson.PrefixPhoneNumber:
		var element = PrefixPerson.PrefixPhoneNumber.new()
		__phones.value.append(element)
		return element
	
	enum PrefixPhoneType {
		MOBILE = 0,
		HOME = 1,
		WORK = 2
	}
	
	class PrefixPhoneNumber:

		...
```

And here's a screenshot of the additions to the UI:

<img width="282" height="673" alt="new_godobuf_ui" src="https://github.com/user-attachments/assets/3d5d9ce8-9c4a-4e19-86c1-767578f78add" />
