### PR TITLE
Added WSL-Filepath support

### DIFF
--- a/addons/protobuf/protobuf_util.gd
+++ b/addons/protobuf/protobuf_util.gd
@@ -33,7 +33,9 @@ static func extract_dir(file_path):
 	var parts = file_path.split("/", false)
 	parts.remove_at(parts.size() - 1)
 	var path
-	if file_path.begins_with("/"):
+    if file_path.begins_with("//"):
+        path = "//"
+	elif file_path.begins_with("/"):
 		path = "/"
 	else:
 		path = ""


### PR DESCRIPTION
I noticed that the parser destroys the filepath for the input proto file when project is on wsl and godot runs on the windows side. 
Just 2 lines fixed the problem, should not change the rest of the behavior.