### PR TITLE
Add optional warning-ignore annotations for strict GDScript projects

### DIFF
--- a/addons/godobuf/godobuf_ui_dock.gd
+++ b/addons/godobuf/godobuf_ui_dock.gd
@@ -112,10 +112,12 @@ func _on_CompileButton_pressed():
 			show_dialog($ClassNameAcceptDialog)
 			return
 
+	var should_add_warning_ignore_annotations = $WarningIgnoreAnnotationsCheckButton.is_pressed()
+
 	var parser = Parser.new()
 	
 	if parser.work(Util.extract_dir(input_file_path), Util.extract_filename(input_file_path), \
-		output_file_path, "res://addons/godobuf/godobuf_core.gd", message_prefix, should_prefix_enums, custom_class_name):
+		output_file_path, "res://addons/godobuf/godobuf_core.gd", message_prefix, should_prefix_enums, custom_class_name, should_add_warning_ignore_annotations):
 		show_dialog($SuccessAcceptDialog)
 	else:
 		show_dialog($FailAcceptDialog)
@@ -147,6 +149,8 @@ func _on_CompileDirectoryButton_pressed():
 			show_dialog($ClassNameAcceptDialog)
 			return
 
+	var should_add_warning_ignore_annotations = $WarningIgnoreAnnotationsCheckButton.is_pressed()
+
 	var parser = Parser.new()
 	if parser.work_directory(
 		input_dir_path,
@@ -154,7 +158,8 @@ func _on_CompileDirectoryButton_pressed():
 		"res://addons/godobuf/godobuf_core.gd",
 		message_prefix,
 		should_prefix_enums,
-		custom_class_name
+		custom_class_name,
+		should_add_warning_ignore_annotations
 	):
 		show_dialog($SuccessAcceptDialog)
 	else:

--- a/addons/godobuf/godobuf_ui_dock.tscn
+++ b/addons/godobuf/godobuf_ui_dock.tscn
@@ -159,6 +159,11 @@ text = "Class name:"
 layout_mode = 2
 size_flags_horizontal = 3
 
+[node name="WarningIgnoreAnnotationsCheckButton" type="CheckButton" parent="."]
+layout_mode = 2
+size_flags_horizontal = 3
+text = "Add warning ignore annotations?"
+
 [node name="HSeparator3" type="HSeparator" parent="."]
 layout_mode = 2
 size_flags_horizontal = 3

--- a/addons/godobuf/parser.gd
+++ b/addons/godobuf/parser.gd
@@ -33,6 +33,7 @@ extends Node
 
 const PROTO_VERSION_CONST : String = "const PROTO_VERSION = "
 const PROTO_VERSION_DEFAULT : String = PROTO_VERSION_CONST + "0"
+const WARNING_IGNORE_ANNOTATIONS : String = "@warning_ignore_start(\"untyped_declaration\")\n@warning_ignore_start(\"inferred_declaration\")\n@warning_ignore_start(\"unsafe_call_argument\")\n@warning_ignore_start(\"unsafe_method_access\")\n\n"
 
 const ONE_OF_CASE_FUNCTION_SUFFIX : String = "_case"
 const ONE_OF_CASE_ENUM_FIELD_SUFFIX : String = "Case"
@@ -50,14 +51,16 @@ class Document:
 
 class PrefixOptions:
 
-	func _init(pre : String, spe : bool = false, cn : String = ""):
+	func _init(pre : String, spe : bool = false, cn : String = "", sawia : bool = false):
 		prefix = pre
 		should_prefix_enums = spe
 		custom_class_name = cn
+		should_add_warning_ignore_annotations = sawia
 
 	var prefix: String = ""
 	var should_prefix_enums : bool
 	var custom_class_name: String = ""
+	var should_add_warning_ignore_annotations : bool = false
 
 
 class TokenPosition:
@@ -2185,6 +2188,8 @@ class Translator:
 		var text : String = ""
 		var nesting : int = 0
 		core_text = core_text.replace(PROTO_VERSION_DEFAULT, PROTO_VERSION_CONST + str(proto_version))
+		if prefix_options.should_add_warning_ignore_annotations:
+			core_text = core_text.replace(PROTO_VERSION_CONST, WARNING_IGNORE_ANNOTATIONS + PROTO_VERSION_CONST)
 		if prefix_options.custom_class_name != "":
 			text += "class_name " + prefix_options.custom_class_name + "\n\n"
 		text += core_text + "\n\n\n"
@@ -2333,12 +2338,13 @@ func work(
 	custom_prefix : String = "",
 	should_prefix_enums : bool = false,
 	custom_class_name : String = "",
+	should_add_warning_ignore_annotations : bool = false,
 ) -> bool:
 
 	var in_full_name : String = path + in_file
 	var imports : Array = []
 	var analyzes : Dictionary = {}
-	var prefix_options : PrefixOptions = PrefixOptions.new(custom_prefix, should_prefix_enums, custom_class_name)
+	var prefix_options : PrefixOptions = PrefixOptions.new(custom_prefix, should_prefix_enums, custom_class_name, should_add_warning_ignore_annotations)
 	
 	print("Compiling source: '", in_full_name, "', output: '", out_file, "'.")
 	print("\n1. Parsing:")
@@ -2394,6 +2400,7 @@ func work_directory(
 	custom_prefix : String = "",
 	should_prefix_enums : bool = false,
 	custom_class_name : String = "",
+	should_add_warning_ignore_annotations : bool = false,
 ) -> bool:
 	var normalized_input_dir = _normalize_dir_path(input_dir)
 	var normalized_output_dir = _normalize_dir_path(output_dir)
@@ -2420,7 +2427,8 @@ func work_directory(
 			core_file,
 			custom_prefix,
 			should_prefix_enums,
-			custom_class_name
+			custom_class_name,
+			should_add_warning_ignore_annotations
 		):
 			return false
 

--- a/addons/godobuf/parser.gd
+++ b/addons/godobuf/parser.gd
@@ -33,7 +33,7 @@ extends Node
 
 const PROTO_VERSION_CONST : String = "const PROTO_VERSION = "
 const PROTO_VERSION_DEFAULT : String = PROTO_VERSION_CONST + "0"
-const WARNING_IGNORE_ANNOTATIONS : String = "@warning_ignore_start(\"untyped_declaration\")\n@warning_ignore_start(\"inferred_declaration\")\n@warning_ignore_start(\"unsafe_call_argument\")\n@warning_ignore_start(\"unsafe_method_access\")\n\n"
+const WARNING_IGNORE_ANNOTATIONS : String = "@warning_ignore_start(\"untyped_declaration\")\n@warning_ignore_start(\"inferred_declaration\")\n@warning_ignore_start(\"unsafe_call_argument\")\n@warning_ignore_start(\"unsafe_method_access\")\n@warning_ignore_start(\"return_value_discarded\")\n\n"
 
 const ONE_OF_CASE_FUNCTION_SUFFIX : String = "_case"
 const ONE_OF_CASE_ENUM_FIELD_SUFFIX : String = "Case"


### PR DESCRIPTION
### Summary
When GDScript is configured with stricter warning settings, the generated Godobuf scripts can emit many editor warnings (especially around inferred/untyped declarations and unsafe call/access patterns in generated code).  
This PR adds a new compile option, **`Add warning ignore annotations?`** (default: off), so users can opt in to suppress those generated-script warnings.

<img width="1012" height="468" alt="errors" src="https://github.com/user-attachments/assets/80f81d54-2e4d-4b9c-b0a2-0938eab42d6b" />

When enabled, Godobuf inserts these annotations above the generated `const PROTO_VERSION = ...` declaration:

- `@warning_ignore_start("untyped_declaration")`
- `@warning_ignore_start("inferred_declaration")`
- `@warning_ignore_start("unsafe_call_argument")`
- `@warning_ignore_start("unsafe_method_access")`
- `@warning_ignore_start("return_value_discarded")`

This keeps strict projects cleaner without changing runtime behavior or serialization logic.

### UI
- Added a new checkbox in the Godobuf dock: **`Add warning ignore annotations?`**

<img width="486" height="853" alt="image" src="https://github.com/user-attachments/assets/3eda57de-9ea7-45ed-96f9-e03b34d9a4a5" />

<img width="879" height="520" alt="image" src="https://github.com/user-attachments/assets/462fb8ee-342c-47f8-9507-78c26a6765e6" />


