### PR TITLE
Make internal and generated classes RefCounted

### DIFF
--- a/addons/godobuf/godobuf_core.gd
+++ b/addons/godobuf/godobuf_core.gd
@@ -134,6 +134,7 @@ enum PB_SERVICE_STATE {
 }
 
 class PBField:
+	extends RefCounted
 	func _init(a_name : String, a_type : int, a_rule : int, a_tag : int, packed : bool, a_value = null):
 		name = a_name
 		type = a_type
@@ -152,12 +153,14 @@ class PBField:
 	var option_default : bool = false
 
 class PBTypeTag:
+	extends RefCounted
 	var ok : bool = false
 	var type : int
 	var tag : int
 	var offset : int
 
 class PBServiceField:
+	extends RefCounted
 	var field : PBField
 	var func_ref = null
 	var state : int = PB_SERVICE_STATE.UNFILLED

--- a/addons/godobuf/parser.gd
+++ b/addons/godobuf/parser.gd
@@ -2073,6 +2073,7 @@ class Translator:
 			elif class_table[class_index].type == Analysis.CLASS_TYPE.MAP:
 				cls_pref += tabulate("class " + class_table[class_index].name + ":\n", nesting)
 			nesting += 1
+			cls_pref += tabulate("extends RefCounted\n", nesting)
 			cls_pref += tabulate("func _init():\n", nesting)
 			text += cls_pref
 			nesting += 1


### PR DESCRIPTION
Enforce RefCounted inheritance for internal and generated classes to avoid memory leaks via automatic memory management in cases where continous use of messages is required (for example, rpc clients).