### PR TITLE
Fix dock not being resizable vertically

### DIFF
--- a/addons/godobuf/godobuf_ui.gd
+++ b/addons/godobuf/godobuf_ui.gd
@@ -37,7 +37,17 @@ var dock
 func _enter_tree():
 	# Initialization of the plugin goes here
 	# First load the dock scene and instance it:
-	dock = preload("res://addons/godobuf/godobuf_ui_dock.tscn").instantiate()
+	var content = preload("res://addons/godobuf/godobuf_ui_dock.tscn").instantiate()
+	# The dock content is a tall stack of controls: its minimum height would
+	# become the dock's minimum height and block vertical resizing. A
+	# ScrollContainer does not propagate the child's minimum height, so the
+	# splitter stays free and the content scrolls instead.
+	dock = ScrollContainer.new()
+	dock.name = "Godobuf"
+	dock.horizontal_scroll_mode = ScrollContainer.SCROLL_MODE_DISABLED
+	content.size_flags_horizontal = Control.SIZE_EXPAND_FILL
+	content.size_flags_vertical = Control.SIZE_EXPAND_FILL
+	dock.add_child(content)
 
 	# Add the loaded scene to the docks:
 	add_control_to_dock(DOCK_SLOT_LEFT_BR, dock)

--- a/addons/godobuf/godobuf_ui_dock.tscn
+++ b/addons/godobuf/godobuf_ui_dock.tscn
@@ -3,11 +3,6 @@
 [ext_resource type="Script" path="res://addons/godobuf/godobuf_ui_dock.gd" id="1"]
 
 [node name="Godobuf" type="VBoxContainer"]
-anchors_preset = 15
-anchor_right = 1.0
-anchor_bottom = 1.0
-offset_right = -731.0
-offset_bottom = -374.0
 size_flags_horizontal = 3
 script = ExtResource("1")
 


### PR DESCRIPTION
Reproduced on Godot v4.7.1.stable.official [a13da4feb].

The dock scene is a VBoxContainer holding ~25 stacked controls, so its
combined minimum height (the sum of its children's) becomes the dock's
minimum height, and the editor splitter cannot be dragged above it.

Wrap the dock content in a ScrollContainer, which does not propagate the
child's minimum height: the splitter stays free and the content scrolls
when the dock is made smaller. Horizontal scrolling is disabled so the
content keeps stretching to the dock width as before.

Also drops the anchor/offset properties from the scene root. They are
overwritten every layout pass now that the parent is a Container, and the
negative offsets (-731, -374) would shrink the root in a non-container
parent.